### PR TITLE
Not supported on MSWin32

### DIFF
--- a/t/02_send.t
+++ b/t/02_send.t
@@ -8,6 +8,8 @@ use HTTP::Status qw(:constants);
 
 use WWW::FCM::HTTP::V1;
 
+plan skip_all => 'Not supported on MSWin32' if $^O eq 'MSWin32';
+
 my $dummy_api_key_json = '{
 "type": "service_account",
 "project_id": "test-project",


### PR DESCRIPTION
CPAN Testers sent me a report mail.

```
WWW-FCM-HTTP-V1-0.01:
- MSWin32-x86-multi-thread / 5.24.0:
  - FAIL http://www.cpantesters.org/cpan/report/20918849-6bf9-1014-929d-71641e4896c8 ("Alexandr Ciornii (CHORNY)" <root@chorny.net ((root))>)

- MSWin32-x86-multi-thread-64int / 5.26.1:
  - FAIL http://www.cpantesters.org/cpan/report/d2ed0f69-6bf6-1014-84ac-3a5646da16f0 ("Alexandr Ciornii (CHORNY)" <root@chorny.net ((root))>)
```

I will skip a test of sending on win32 because it's not supported.